### PR TITLE
Optimize primitive collection parsing

### DIFF
--- a/benchmarks/bench.mjs
+++ b/benchmarks/bench.mjs
@@ -8,7 +8,10 @@ let publishedVersion
 try {
   publishedVersion = JSON.parse(
     readFileSync(
-      new URL('./published/node_modules/runcheck/package.json', import.meta.url),
+      new URL(
+        './published/node_modules/runcheck/package.json',
+        import.meta.url,
+      ),
       'utf8',
     ),
   ).version
@@ -60,6 +63,12 @@ function getSchemas(rc) {
   return {
     obj: objSchema,
     stringObj: rc.rc_object({ string: rc.rc_string }),
+    numberArray: rc.rc_array(rc.rc_number),
+    numberRecord: rc.rc_record(rc.rc_number),
+    strictObject: rc.rc_obj_strict({
+      string: rc.rc_string,
+      number: rc.rc_number,
+    }),
     largeArray: rc.rc_array(
       rc.rc_object({
         string: rc.rc_string,
@@ -111,6 +120,16 @@ const deoptObjects = Array.from({ length: 64 }, (_, i) => ({
   string: `string${i}`,
   [`key${i}`]: i,
 }))
+
+const numberArray = Array.from({ length: 100 }, (_, i) => i + 0.5)
+const invalidNumberArray = [...numberArray.slice(0, -1), 'invalid']
+const numberRecord = Object.fromEntries(
+  Array.from({ length: 100 }, (_, i) => [`key${i}`, i + 0.5]),
+)
+const invalidNestedObject = {
+  ...validateData,
+  deeplyNested: { ...validateData.deeplyNested, bool: 'invalid' },
+}
 
 const largeArray = Array.from({ length: 100 }, (_, i) => ({
   string: `string${i}`,
@@ -186,6 +205,60 @@ group('parse nested object', () => {
 
   bench(publishedLabel, () => {
     sink = published.rc_unwrap(published.rc_parse(validateData, pub.obj))
+  })
+})
+
+group('reject invalid nested object', () => {
+  baseline(currentLabel, () => {
+    sink = current.rc_parse(invalidNestedObject, cur.obj)
+  })
+
+  bench(publishedLabel, () => {
+    sink = published.rc_parse(invalidNestedObject, pub.obj)
+  })
+})
+
+group('parse number array (100 values)', () => {
+  baseline(currentLabel, () => {
+    sink = current.rc_unwrap(current.rc_parse(numberArray, cur.numberArray))
+  })
+
+  bench(publishedLabel, () => {
+    sink = published.rc_unwrap(published.rc_parse(numberArray, pub.numberArray))
+  })
+})
+
+group('reject number array at last item (100 values)', () => {
+  baseline(currentLabel, () => {
+    sink = current.rc_parse(invalidNumberArray, cur.numberArray)
+  })
+
+  bench(publishedLabel, () => {
+    sink = published.rc_parse(invalidNumberArray, pub.numberArray)
+  })
+})
+
+group('parse number record (100 values)', () => {
+  baseline(currentLabel, () => {
+    sink = current.rc_unwrap(current.rc_parse(numberRecord, cur.numberRecord))
+  })
+
+  bench(publishedLabel, () => {
+    sink = published.rc_unwrap(
+      published.rc_parse(numberRecord, pub.numberRecord),
+    )
+  })
+})
+
+group('parse strict object', () => {
+  const input = { string: 'value', number: 1 }
+
+  baseline(currentLabel, () => {
+    sink = current.rc_unwrap(current.rc_parse(input, cur.strictObject))
+  })
+
+  bench(publishedLabel, () => {
+    sink = published.rc_unwrap(published.rc_parse(input, pub.strictObject))
   })
 })
 

--- a/benchmarks/published/package.json
+++ b/benchmarks/published/package.json
@@ -2,6 +2,6 @@
   "name": "runcheck-published",
   "private": true,
   "dependencies": {
-    "runcheck": "^1.19.0"
+    "runcheck": "latest"
   }
 }

--- a/benchmarks/setup-published.mjs
+++ b/benchmarks/setup-published.mjs
@@ -1,5 +1,5 @@
 import { execSync } from 'node:child_process'
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -26,13 +26,9 @@ if (installedVersion === latestVersion) {
   console.log(`Installing published runcheck@${latestVersion}...`)
 
   mkdirSync(publishedDir, { recursive: true })
-  writeFileSync(
-    join(publishedDir, 'package.json'),
-    `${JSON.stringify({ name: 'runcheck-published', private: true }, null, 2)}\n`,
-  )
 
   execSync(
-    `npm install runcheck@${latestVersion} --no-audit --no-fund --no-package-lock`,
+    `npm install runcheck@${latestVersion} --no-save --no-audit --no-fund --no-package-lock`,
     { cwd: publishedDir, stdio: 'inherit' },
   )
 }

--- a/src/runcheck.ts
+++ b/src/runcheck.ts
@@ -1126,18 +1126,15 @@ export function rc_record<V>(
         if (!isObject(inputObj)) return false
 
         const resultObj: Record<any, string> = {} as any
-        const resultErrors: ErrorWithPath[] = []
+        let resultErrors: ErrorWithPath[] | undefined
 
         const parentPath = ctx.path_
+        const primitiveParserKind = getPrimitiveParserKind(valueType)
 
         for (const [key, inputValue] of Object.entries(inputObj)) {
-          const subPath =
-            key === '' || key.includes(' ') ? `['${key}']` : `.${key}`
-
-          const path = `${parentPath}${subPath}`
-          ctx.path_ = path
-
           if (checkKey && !checkKey(key)) {
+            ctx.path_ = `${parentPath}${getKeySubPath(key)}`
+            resultErrors ??= []
             resultErrors.push(
               getWarningOrErrorWithPath(ctx, `Key '${key}' is not allowed`),
             )
@@ -1145,6 +1142,16 @@ export function rc_record<V>(
           }
 
           const input = inputObj[key]
+
+          if (
+            primitiveParserKind !== 0 &&
+            isPrimitiveParseSuccess(primitiveParserKind, inputValue)
+          ) {
+            resultObj[key] = input
+            continue
+          }
+
+          ctx.path_ = `${parentPath}${getKeySubPath(key)}`
 
           const parseResult = valueType._parse_(inputValue, ctx)
 
@@ -1154,6 +1161,7 @@ export function rc_record<V>(
           //
           else {
             const errors = parseResult.errors
+            resultErrors ??= []
 
             for (const subError of errors) {
               resultErrors.push(subError)
@@ -1165,7 +1173,7 @@ export function rc_record<V>(
           }
         }
 
-        if (resultErrors.length > 0) {
+        if (resultErrors) {
           if (looseCheck) {
             addWarnings(ctx, resultErrors)
           } else {
@@ -1216,9 +1224,7 @@ function checkArrayItems(
     const type: RcType<any> = isTuple ? types[index] : types
 
     const subPath = `[${index}]`
-
     const path = `${parentPath}${subPath}`
-
     ctx.path_ = path
 
     if (options?.filter) {
@@ -1322,6 +1328,91 @@ function checkArrayItems(
   return { errors: false, data: arrayResult }
 }
 
+function checkArrayItemsFast(
+  input: any[],
+  type: RcType<any>,
+  primitiveParserKind: number,
+  ctx: ParseResultCtx,
+): IsValid<any[]> {
+  const arrayResult = new Array<any>(input.length)
+  const parentPath = ctx.path_
+
+  for (let index = 0; index < input.length; index++) {
+    const item = input[index]
+
+    if (isPrimitiveParseSuccess(primitiveParserKind, item)) {
+      arrayResult[index] = item
+      continue
+    }
+
+    ctx.path_ = `${parentPath}[${index}]`
+
+    const parseResult = type._parse_(item, ctx)
+
+    if (!parseResult.ok) {
+      return { errors: parseResult.errors, data: undefined }
+    }
+
+    arrayResult[index] = parseResult.data
+  }
+
+  ctx.path_ = parentPath
+
+  return { errors: false, data: arrayResult }
+}
+
+function getKeySubPath(key: string): string {
+  return key === '' || key.includes(' ') ? `['${key}']` : `.${key}`
+}
+
+// Numeric tags keep the hot array/record loops compact and let them skip both
+// path construction and a generic parser call for canonical primitive success.
+function getPrimitiveParserKind(type: RcType<any>): number {
+  const parseFn = type._parse_
+
+  switch (type._shape_) {
+    case 'string':
+      return parseFn === rc_string._parse_ ? 1 : 0
+    case 'number':
+      return parseFn === rc_number._parse_ ? 2 : 0
+    case 'boolean':
+      return parseFn === rc_boolean._parse_ ? 3 : 0
+    case 'any':
+      return parseFn === rc_any._parse_ ? 4 : 0
+    case 'unknown':
+      return parseFn === rc_unknown._parse_ ? 4 : 0
+    case 'null':
+      return parseFn === rc_null._parse_ ? 5 : 0
+    case 'undefined':
+      return parseFn === rc_undefined._parse_ ? 6 : 0
+    case 'date':
+      return parseFn === rc_date._parse_ ? 7 : 0
+    default:
+      return 0
+  }
+}
+
+function isPrimitiveParseSuccess(kind: number, input: any): boolean {
+  switch (kind) {
+    case 1:
+      return typeof input === 'string'
+    case 2:
+      return typeof input === 'number' && !Number.isNaN(input)
+    case 3:
+      return typeof input === 'boolean'
+    case 4:
+      return true
+    case 5:
+      return input === null
+    case 6:
+      return input === undefined
+    case 7:
+      return input instanceof Date && !Number.isNaN(input.getTime())
+    default:
+      return false
+  }
+}
+
 type ArrayOptions<T extends RcType<any>> = {
   unique?: RcInferType<T> extends Record<string, any> ?
     keyof RcInferType<T> | ((parsedItem: RcInferType<T>) => any)
@@ -1344,7 +1435,15 @@ export function rc_array<T extends RcType<any>>(
 
         if (input.length === 0) return true
 
-        return checkArrayItems.call(this, input, type, ctx, false, options)
+        if (options) {
+          return checkArrayItems.call(this, input, type, ctx, false, options)
+        }
+
+        const primitiveParserKind = getPrimitiveParserKind(type)
+
+        return primitiveParserKind ?
+            checkArrayItemsFast(input, type, primitiveParserKind, ctx)
+          : checkArrayItems.call(this, input, type, ctx)
       })
     },
   }
@@ -1398,7 +1497,7 @@ export function rc_disable_loose_array<T extends RcType<any>>(
 
           if (input.length === 0) return true
 
-          return checkArrayItems.call(this, input, type, ctx, false)
+          return checkArrayItems.call(this, input, type, ctx)
         })
       },
     }


### PR DESCRIPTION
## Summary

- add fast paths for primitive arrays and records that avoid per-item path construction and generic parser calls on valid inputs
- preserve the existing parsing path for custom schemas and option-bearing arrays to avoid performance regressions
- expand benchmarks for primitive arrays, late rejection, records, strict objects, and invalid nested objects
- keep published benchmark setup from rewriting its tracked fixture

## Performance

Compared with published runcheck 1.20.0 on an Apple M1 Pro:

- number arrays: 11.5x faster
- late number-array rejection: 5.08x faster
- number records: 1.29x faster
- large composite arrays: 1.23x faster
- union/discriminated payloads: 1.18-1.19x faster
- schema creation: equivalent

The shared minified chunk increases by about 1 KB raw / 343 bytes gzip.

## Validation

- `pnpm test` — 457 tests passed, including type tests
- `pnpm lint`
- `pnpm build:no-test`
- `node benchmarks/bench.mjs`
